### PR TITLE
Fixes and QoL Additions

### DIFF
--- a/bio_hansel/const.py
+++ b/bio_hansel/const.py
@@ -48,7 +48,7 @@ n_tiles_matching_positive_expected
 n_tiles_matching_subtype
 n_tiles_matching_subtype_expected
 file_path
-coverage
+avg_tile_coverage
 qc_status
 qc_message
 """.strip().split('\n')

--- a/bio_hansel/const.py
+++ b/bio_hansel/const.py
@@ -58,5 +58,5 @@ qc_status
 qc_message
 """.strip().split('\n')
 
-REGEX_FASTQ = re.compile(r'^(.+)\.(fastq|fq)(\.gz)?$')
+REGEX_FASTQ = re.compile(r'^(.+)\.(fastq|fq|fastqsanger)(\.gz)?$')
 REGEX_FASTA = re.compile(r'^.+\.(fasta|fa|fna|fas)(\.gz)?$')

--- a/bio_hansel/const.py
+++ b/bio_hansel/const.py
@@ -27,8 +27,8 @@ bitscore
 qlen
 slen
 sseq
-coverage
 is_trunc
+coverage
 '''.strip().split('\n')
 
 # These are present within the subtype module.
@@ -57,6 +57,7 @@ qc_message
 SIMPLE_SUMMARY_COLS = """
 sample
 subtype
+coverage
 qc_status
 qc_message
 """.strip().split('\n')

--- a/bio_hansel/const.py
+++ b/bio_hansel/const.py
@@ -48,8 +48,11 @@ n_tiles_matching_positive_expected
 n_tiles_matching_subtype
 n_tiles_matching_subtype_expected
 file_path
+coverage
 qc_status
-qc_message""".strip().split('\n')
+qc_message
+""".strip().split('\n')
+
 
 SIMPLE_SUMMARY_COLS = """
 sample

--- a/bio_hansel/const.py
+++ b/bio_hansel/const.py
@@ -64,3 +64,5 @@ qc_message
 
 REGEX_FASTQ = re.compile(r'^(.+)\.(fastq|fq|fastqsanger)(\.gz)?$')
 REGEX_FASTA = re.compile(r'^.+\.(fasta|fa|fna|fas)(\.gz)?$')
+
+JSON_EXT_TMPL = '{}.json'

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -11,7 +11,7 @@ import pandas as pd
 import re
 
 from . import program_desc, __version__
-from .const import SUBTYPE_SUMMARY_COLS, REGEX_FASTQ, REGEX_FASTA
+from .const import SUBTYPE_SUMMARY_COLS, REGEX_FASTQ, REGEX_FASTA, JSON_EXT_TMPL
 from .subtype import Subtype
 from .subtype_stats import subtype_counts
 from .subtyper import \
@@ -268,10 +268,13 @@ def main():
     dfsummary = dfsummary[SUBTYPE_SUMMARY_COLS]
     dfsummary = dfsummary.dropna(axis=1, how='all')
 
+    kwargs_for_pd_to_table = dict(sep='\t', index=None, float_format='%.3f')
+    kwargs_for_pd_to_json = dict(orient='records')
+
     if output_summary_path:
-        dfsummary.to_csv(output_summary_path, sep='\t', index=None, float_format='%.3f')
+        dfsummary.to_csv(output_summary_path, **kwargs_for_pd_to_table)
         if args.json:
-            dfsummary.to_json("{}.json".format(output_summary_path), orient='records')
+            dfsummary.to_json(JSON_EXT_TMPL.format(output_summary_path), **kwargs_for_pd_to_json)
         logging.info('Wrote subtyping output summary to %s', output_summary_path)
     else:
         # if no output path specified for the summary results, then print to stdout
@@ -279,15 +282,15 @@ def main():
 
     if output_tile_results:
         dfall = pd.concat(dfs)  # type: pd.DataFrame
-        dfall.to_csv(output_tile_results, sep='\t', index=None, float_format='%.3f')
+        dfall.to_csv(output_tile_results, **kwargs_for_pd_to_table)
         if args.json:
-            dfall.to_json("{}.json".format(output_tile_results), orient='records')
+            dfall.to_json(JSON_EXT_TMPL.format(output_tile_results), **kwargs_for_pd_to_json)
 
     if output_simple_summary_path:
         df_simple_summary = dfsummary[['sample', 'subtype', 'coverage', 'qc_status', 'qc_message']]
-        df_simple_summary.to_csv(output_simple_summary_path, sep='\t', index=None, float_format='%.3f')
+        df_simple_summary.to_csv(output_simple_summary_path, **kwargs_for_pd_to_table)
         if args.json:
-            df_simple_summary.to_json("{}.json".format(output_simple_summary_path), orient='records')
+            df_simple_summary.to_json(JSON_EXT_TMPL.format(output_simple_summary_path), **kwargs_for_pd_to_json)
 
 
 if __name__ == '__main__':

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -102,6 +102,9 @@ def init_parser():
     parser.add_argument('--min-ambiguous-tiles',
                         type=int,
                         help='Minimum number of missing tiles to be considered an ambiguous result')
+    parser.add_argument('--low-cov-warning',
+                        type=int,
+                        help='Overall tile coverage below this value will trigger a low coverage warning')
     parser.add_argument('--max-intermediate-tiles',
                         type=float,
                         help='Decimal proportion of maximum allowable missing tiles to be considered an intermediate subtype. (0.0 - 1.0)')

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -84,6 +84,9 @@ def init_parser():
     parser.add_argument('--force',
                         action='store_true',
                         help='Force existing output files to be overwritten')
+    parser.add_argument('--json',
+                        action='store_true',
+                        help='Output JSON representation of output files')
     parser.add_argument('--min-kmer-freq',
                         type=int,
                         help='Min k-mer freq/coverage')
@@ -260,8 +263,12 @@ def main():
 
     dfsummary = pd.DataFrame(subtype_results)
     dfsummary = dfsummary[SUBTYPE_SUMMARY_COLS]
+    dfsummary = dfsummary.dropna(axis=1, how='all')
+
     if output_summary_path:
-        dfsummary.to_csv(output_summary_path, sep='\t', index=None)
+        dfsummary.to_csv(output_summary_path, sep='\t', index=None, float_format='%.3f')
+        if args.json:
+            dfsummary.to_json("{}.json".format(output_summary_path), orient='records')
         logging.info('Wrote subtyping output summary to %s', output_summary_path)
     else:
         # if no output path specified for the summary results, then print to stdout
@@ -269,11 +276,15 @@ def main():
 
     if output_tile_results:
         dfall = pd.concat(dfs)  # type: pd.DataFrame
-        dfall.to_csv(output_tile_results, sep='\t', index=None)
+        dfall.to_csv(output_tile_results, sep='\t', index=None, float_format='%.3f')
+        if args.json:
+            dfall.to_json("{}.json".format(output_tile_results), orient='records')
 
     if output_simple_summary_path:
-        df_simple_summary = dfsummary[['sample', 'subtype', 'qc_status', 'qc_message']]
-        df_simple_summary.to_csv(output_simple_summary_path, sep='\t', index=None)
+        df_simple_summary = dfsummary[['sample', 'subtype', 'coverage', 'qc_status', 'qc_message']]
+        df_simple_summary.to_csv(output_simple_summary_path, sep='\t', index=None, float_format='%.3f')
+        if args.json:
+            df_simple_summary.to_json("{}.json".format(output_simple_summary_path), orient='records')
 
 
 if __name__ == '__main__':

--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -287,7 +287,11 @@ def main():
             dfall.to_json(JSON_EXT_TMPL.format(output_tile_results), **kwargs_for_pd_to_json)
 
     if output_simple_summary_path:
-        df_simple_summary = dfsummary[['sample', 'subtype', 'coverage', 'qc_status', 'qc_message']]
+        if 'avg_tile_coverage' in dfsummary.columns:
+            df_simple_summary = dfsummary[['sample', 'subtype', 'avg_tile_coverage', 'qc_status', 'qc_message']]
+        else:
+            df_simple_summary = dfsummary[['sample', 'subtype', 'qc_status', 'qc_message']]
+
         df_simple_summary.to_csv(output_simple_summary_path, **kwargs_for_pd_to_table)
         if args.json:
             df_simple_summary.to_json(JSON_EXT_TMPL.format(output_simple_summary_path), **kwargs_for_pd_to_json)

--- a/bio_hansel/qc/__init__.py
+++ b/bio_hansel/qc/__init__.py
@@ -12,7 +12,8 @@ from ..qc.checks import \
     is_mixed_subtype, \
     is_maybe_intermediate_subtype, \
     is_missing_too_many_target_sites, \
-    is_missing_downstream_targets
+    is_missing_downstream_targets, \
+    is_overall_coverage_low
 
 
 CHECKS = [is_missing_tiles,
@@ -20,6 +21,7 @@ CHECKS = [is_missing_tiles,
           is_missing_too_many_target_sites,
           is_missing_downstream_targets,
           is_maybe_intermediate_subtype,
+          is_overall_coverage_low
           ] # type: List[Callable[[Subtype, DataFrame, SubtypingParams], Tuple[str, str]]]
 
 

--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -10,6 +10,24 @@ from ..qc.utils import get_conflicting_tiles, get_num_pos_neg_tiles
 from ..subtype import Subtype
 
 
+def is_overall_coverage_low(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[Optional[str], Optional[str]]:
+    if not st.are_subtypes_consistent:
+        return None, None
+    if st.subtype is None:
+        return None, None
+    if not st.is_fastq_input():
+        return None, None
+
+    if st.coverage < p.min_coverage_warning:
+        return QC.WARNING, '{}: Low coverage for all tiles ({:.3f} < {} expected)'.format(
+            QC.LOW_COVERAGE_WARNING,
+            st.coverage,
+            p.min_coverage_warning
+        )
+
+    return None, None
+
+
 def is_missing_tiles(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[Optional[str], Optional[str]]:
     """Are there more missing tiles than tolerated?
 

--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -14,7 +14,7 @@ def is_overall_coverage_low(st: Subtype, df: DataFrame, p: SubtypingParams) -> T
     if not st.are_subtypes_consistent \
             or st.subtype is None \
             or not st.is_fastq_input():
-                return None, None
+        return None, None
 
     if st.avg_tile_coverage < p.min_coverage_warning:
         return QC.WARNING, '{}: Low coverage for all tiles ({:.3f} < {} expected)'.format(
@@ -127,7 +127,7 @@ def is_missing_too_many_target_sites(st: Subtype, df: DataFrame, p: SubtypingPar
     """
     if not st.are_subtypes_consistent \
             or st.subtype is None:
-                return None, None
+        return None, None
 
     potential_subtypes = st.all_subtypes.split('; ')
     uniq_positions = {y for x in potential_subtypes for y in st.scheme_subtype_counts[x].refpositions}
@@ -190,7 +190,7 @@ def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams
     '''
     if not st.are_subtypes_consistent \
             or st.subtype is None:
-                return None, None
+        return None, None
 
     total_subtype_tiles = int(st.n_tiles_matching_subtype_expected)
     total_subtype_tiles_hits = int(st.n_tiles_matching_subtype)

--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -11,17 +11,15 @@ from ..subtype import Subtype
 
 
 def is_overall_coverage_low(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[Optional[str], Optional[str]]:
-    if not st.are_subtypes_consistent:
-        return None, None
-    if st.subtype is None:
-        return None, None
-    if not st.is_fastq_input():
-        return None, None
+    if not st.are_subtypes_consistent \
+            or st.subtype is None \
+            or not st.is_fastq_input():
+                return None, None
 
-    if st.coverage < p.min_coverage_warning:
+    if st.avg_tile_coverage < p.min_coverage_warning:
         return QC.WARNING, '{}: Low coverage for all tiles ({:.3f} < {} expected)'.format(
             QC.LOW_COVERAGE_WARNING,
-            st.coverage,
+            st.avg_tile_coverage,
             p.min_coverage_warning
         )
 
@@ -127,10 +125,9 @@ def is_missing_too_many_target_sites(st: Subtype, df: DataFrame, p: SubtypingPar
     Returns:
         None, None if less missing targets than tolerated; otherwise, "FAIL", error message
     """
-    if not st.are_subtypes_consistent:
-        return None, None
-    if st.subtype is None:
-        return None, None
+    if not st.are_subtypes_consistent \
+            or st.subtype is None:
+                return None, None
 
     potential_subtypes = st.all_subtypes.split('; ')
     uniq_positions = {y for x in potential_subtypes for y in st.scheme_subtype_counts[x].refpositions}
@@ -191,10 +188,9 @@ def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams
     Returns:
         None, None if no intermediate subtype possible; otherwise, "FAIL", error message
     '''
-    if not st.are_subtypes_consistent:
-        return None, None
-    if st.subtype is None:
-        return None, None
+    if not st.are_subtypes_consistent \
+            or st.subtype is None:
+                return None, None
 
     total_subtype_tiles = int(st.n_tiles_matching_subtype_expected)
     total_subtype_tiles_hits = int(st.n_tiles_matching_subtype)

--- a/bio_hansel/qc/const.py
+++ b/bio_hansel/qc/const.py
@@ -10,4 +10,5 @@ class QC:
     AMBIGUOUS_RESULTS_ERROR_3 = 'Ambiguous Results Error 3'
     UNCONFIDENT_RESULTS_ERROR_4 = 'Unconfident Results Error 4'
     INTERMEDIATE_SUBTYPE_WARNING = 'Intermediate Subtype'
+    LOW_COVERAGE_WARNING = 'Low Coverage'
     NO_SUBTYPE_RESULT = 'No subtype result!'

--- a/bio_hansel/subtype.py
+++ b/bio_hansel/subtype.py
@@ -30,7 +30,7 @@ class Subtype(object):
     n_tiles_matching_negative_expected = attr.ib(default=0)
     n_tiles_matching_subtype_expected = attr.ib(default=0)
     n_negative_tiles_matching_subtype_expected = attr.ib(default=0)
-    coverage = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
+    coverage = attr.ib(default=None)
     qc_status = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     qc_message = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     scheme_subtype_counts = attr.ib(default=None, repr=False)

--- a/bio_hansel/subtype.py
+++ b/bio_hansel/subtype.py
@@ -30,7 +30,7 @@ class Subtype(object):
     n_tiles_matching_negative_expected = attr.ib(default=0)
     n_tiles_matching_subtype_expected = attr.ib(default=0)
     n_negative_tiles_matching_subtype_expected = attr.ib(default=0)
-    coverage = attr.ib(default=None)
+    avg_tile_coverage = attr.ib(default=None)
     qc_status = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     qc_message = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     scheme_subtype_counts = attr.ib(default=None, repr=False)

--- a/bio_hansel/subtype.py
+++ b/bio_hansel/subtype.py
@@ -30,6 +30,7 @@ class Subtype(object):
     n_tiles_matching_negative_expected = attr.ib(default=0)
     n_tiles_matching_subtype_expected = attr.ib(default=0)
     n_negative_tiles_matching_subtype_expected = attr.ib(default=0)
+    coverage = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     qc_status = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     qc_message = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     scheme_subtype_counts = attr.ib(default=None, repr=False)

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -233,18 +233,17 @@ def parallel_blastn_query_contigs(input_genomes: List[Tuple[str, str]],
     logging.info('Initializing thread pool with %s threads', n_threads)
     pool = Pool(processes=n_threads)
     logging.info('Running analysis asynchronously on %s input genomes', len(input_genomes))
-    res = [pool.apply_async(subtype_contigs_blastn, (subtyping_params,
-                                                     scheme,
-                                                     input_fasta,
+    res = [pool.apply_async(subtype_contigs_blastn, (input_fasta,
                                                      genome_name,
-                                                     tmp_dir,
+                                                     scheme,
+                                                     subtyping_params,
                                                      scheme_name,
-                                                     scheme_subtype_counts))
+                                                     scheme_subtype_counts,
+                                                     tmp_dir))
            for input_fasta, genome_name in input_genomes]
     logging.info('Parallel analysis complete! Retrieving analysis results')
     outputs = [x.get() for x in res]
     return outputs
-
 
 def subtype_contigs_ac(fasta_path: str,
                        genome_name: str,

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -151,6 +151,7 @@ def subtype_reads_jellyfish(reads: Union[str, List[str]],
 
         st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
 
+        st.coverage = "{0:.3f}".format(df['freq'].mean())
         df['scheme'] = scheme_name or scheme
         df['scheme_version'] = scheme_version
         df['qc_status'] = st.qc_status
@@ -473,6 +474,7 @@ def subtype_reads_ac(reads: Union[str, List[str]],
     st.non_present_subtypes = [x for x in possible_downstream_subtypes
                                if not (df.subtype == x).any()]
     st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
+    st.coverage = "{0:.3f}".format(df['freq'].mean())
     df['sample'] = genome_name
     df['scheme'] = scheme_name or scheme
     df['scheme_version'] = scheme_version

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -149,7 +149,7 @@ def subtype_reads_jellyfish(reads: Union[str, List[str]],
                      threads=threads) as jfer:
         st, df = jfer.summary()
 
-        st.coverage = df['freq'].mean()
+        st.avg_tile_coverage = df['freq'].mean()
         st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
         df['scheme'] = scheme_name or scheme
         df['scheme_version'] = scheme_version
@@ -472,7 +472,7 @@ def subtype_reads_ac(reads: Union[str, List[str]],
                                     if re.search("^({})(\.)(\d)$".format(re.escape(st.subtype)), s)]
     st.non_present_subtypes = [x for x in possible_downstream_subtypes
                                if not (df.subtype == x).any()]
-    st.coverage = df['freq'].mean()
+    st.avg_tile_coverage = df['freq'].mean()
     st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
     df['sample'] = genome_name
     df['scheme'] = scheme_name or scheme

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -245,6 +245,7 @@ def parallel_blastn_query_contigs(input_genomes: List[Tuple[str, str]],
     outputs = [x.get() for x in res]
     return outputs
 
+
 def subtype_contigs_ac(fasta_path: str,
                        genome_name: str,
                        scheme: str,

--- a/bio_hansel/subtyper.py
+++ b/bio_hansel/subtyper.py
@@ -149,9 +149,8 @@ def subtype_reads_jellyfish(reads: Union[str, List[str]],
                      threads=threads) as jfer:
         st, df = jfer.summary()
 
+        st.coverage = df['freq'].mean()
         st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
-
-        st.coverage = "{0:.3f}".format(df['freq'].mean())
         df['scheme'] = scheme_name or scheme
         df['scheme_version'] = scheme_version
         df['qc_status'] = st.qc_status
@@ -473,8 +472,8 @@ def subtype_reads_ac(reads: Union[str, List[str]],
                                     if re.search("^({})(\.)(\d)$".format(re.escape(st.subtype)), s)]
     st.non_present_subtypes = [x for x in possible_downstream_subtypes
                                if not (df.subtype == x).any()]
+    st.coverage = df['freq'].mean()
     st.qc_status, st.qc_message = perform_quality_check(st, df, subtyping_params)
-    st.coverage = "{0:.3f}".format(df['freq'].mean())
     df['sample'] = genome_name
     df['scheme'] = scheme_name or scheme
     df['scheme_version'] = scheme_version

--- a/bio_hansel/subtyping_params.py
+++ b/bio_hansel/subtyping_params.py
@@ -9,6 +9,7 @@ class SubtypingParams(object):
     max_perc_intermediate_tiles = attr.ib(default=0.05, validator=attr.validators.instance_of(float))
     min_kmer_freq = attr.ib(default=8, validator=attr.validators.instance_of((float, int)))
     max_kmer_freq = attr.ib(default=1000, validator=attr.validators.instance_of((float, int)))
+    min_coverage_warning = attr.ib(default=20, validator=attr.validators.instance_of((float, int)))
 
     @max_perc_missing_tiles.validator
     def _validate_max_perc_missing_tiles(self, attribute, value):

--- a/bio_hansel/utils.py
+++ b/bio_hansel/utils.py
@@ -260,4 +260,7 @@ def init_subtyping_params(args: Optional[Any] = None,
             subtyping_params.min_ambiguous_tiles = args.min_ambiguous_tiles
         if args.max_intermediate_tiles:
             subtyping_params.max_perc_intermediate_tiles = args.max_intermediate_tiles
+        if args.low_cov_warning:
+            subtyping_params.min_coverage_warning = args.low_cov_warning
+
     return subtyping_params

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -9,6 +9,19 @@ from bio_hansel.subtyper import subtype_reads_ac, subtype_contigs_ac
 genome_name = 'test'
 
 
+def test_low_coverage():
+    scheme = 'heidelberg'
+    fastq = 'tests/data/SRR1696752/SRR1696752.fastq'
+    st, df = subtype_reads_ac(reads=fastq, genome_name=genome_name, scheme=scheme)
+    assert isinstance(st, Subtype)
+    assert isinstance(df, DataFrame)
+    assert st.is_fastq_input()
+    assert st.scheme == scheme
+    assert QC.LOW_COVERAGE_WARNING in st.qc_message
+    assert 'Low Coverage: Low coverage for all tiles (7.439 < 20 expected)' in st.qc_message
+    assert st.qc_status == QC.FAIL
+
+
 def test_intermediate_subtype():
     scheme = 'enteritidis'
     fastq = 'tests/data/Retro1000data/10-1358.fastq'


### PR DESCRIPTION
1) Adding fastqsanger to the list of fastq regex patterns.
- This is needed as there were cases where fastqsanger wasn't being considered as a fastq file, while lead to kmer_cov_freq not being considered.
2) Adding average coverage value column to the subtyping result. 
- Requested so that a user can check coverage in the results.
3) Fixing order of parameters for blast method.
- Incorrect order of parameters was causing the blast method to fail.

Further questions:
- Do you think it's a good idea to have coverage present in the subtyping result? Or would you rather this be a new column in the DataFrame for match_results?
