### PR TITLE
Missing Column Fix & Missing Tiles Test for Mixed Subtypes

### DIFF
--- a/bio_hansel/main.py
+++ b/bio_hansel/main.py
@@ -266,7 +266,9 @@ def main():
 
     dfsummary = pd.DataFrame(subtype_results)
     dfsummary = dfsummary[SUBTYPE_SUMMARY_COLS]
-    dfsummary = dfsummary.dropna(axis=1, how='all')
+
+    if dfsummary['avg_tile_coverage'].isnull().all():
+        dfsummary = dfsummary.drop(labels='avg_tile_coverage', axis=1)
 
     kwargs_for_pd_to_table = dict(sep='\t', index=None, float_format='%.3f')
     kwargs_for_pd_to_json = dict(orient='records')

--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -45,6 +45,7 @@ def is_missing_tiles(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[Op
     if st.are_subtypes_consistent:
         return check_for_missing_tiles(is_fastq=st.is_fastq_input(),
                                        curr_subtype=st.subtype,
+                                       scheme=st.scheme,
                                        df=df,
                                        exp=int(st.n_tiles_matching_all_expected),
                                        obs=int(st.n_tiles_matching_all),
@@ -53,21 +54,21 @@ def is_missing_tiles(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[Op
         message_list = []
 
         subtype_list = st.subtype.split(';')
-        n_tiles_matching_all_expected = st.n_tiles_matching_all_expected.split(';')
-        n_tiles_matching_subtype_exp = st.n_tiles_matching_positive_expected.split(';')
+        n_tiles_matching_expected = st.n_tiles_matching_all_expected.split(';')
 
         dfpos = df[df.is_pos_tile]
         mixed_subtype_counts = get_mixed_subtype_tile_counts(dfpos=dfpos,
                                                              subtype_list=subtype_list)
-        for curr_subtype, exp, st_exp in zip(subtype_list, n_tiles_matching_all_expected, n_tiles_matching_subtype_exp):
+
+        for curr_subtype, exp in zip(subtype_list, n_tiles_matching_expected):
             # We can omit the status because there will be a fail status already from non consistent subtypes.
             _, curr_messages = check_for_missing_tiles(is_fastq=st.is_fastq_input(),
                                                        curr_subtype=curr_subtype,
                                                        scheme=st.scheme,
                                                        df=df,
-                                                       exp=(int(exp) + int(st_exp)),
+                                                       exp=int(exp),
                                                        obs=(mixed_subtype_counts.get(curr_subtype) +
-                                                       int(st.n_tiles_matching_all)),
+                                                            int(st.n_tiles_matching_negative)),
                                                        p=p)
 
             message_list.append(curr_messages)

--- a/bio_hansel/qc/utils.py
+++ b/bio_hansel/qc/utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, Optional
+from typing import Tuple, Optional, List, Any, Dict
 
 from pandas import DataFrame
 
@@ -39,3 +39,13 @@ def get_num_pos_neg_tiles(st: Subtype, df: DataFrame) -> Tuple[int, int]:
     """
     dfst = df[(df['subtype'] == str(st.subtype))]
     return dfst[dfst['is_pos_tile']].shape[0], dfst[~dfst['is_pos_tile']].shape[0]
+
+
+def get_mixed_subtype_tile_counts(dfpos: DataFrame, subtype_list: List[Any]) -> Dict[str, int]:
+    st_pos_tiles = {}
+
+    for st in subtype_list:
+        bs = dfpos.subtype == [st[:x] for x in dfpos.subtype.str.len()]
+        st_pos_tiles[st] = bs.sum()
+
+    return st_pos_tiles

--- a/tests/test_qc_utils.py
+++ b/tests/test_qc_utils.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+
+from bio_hansel.qc.utils import get_mixed_subtype_tile_counts
+
+
+def test_get_mixed_subtype_tile_counts():
+    """
+    Subtype 2.1 should have positive tiles (2, 2, 2.1, 2.1, 2.1) == 5 pos tiles
+    Subtype 2.2 should have positive tiles (2, 2, 2.2) == 3 pos tiles
+    Subtype 0 should have 1 positive tile (0)
+    """
+    subtype_list = ['2.1', '2.2', '0']
+    data = {'subtype': ['1', '2', '2', '2.1', '2.1', '2.1', '2.2', '2.3', '2.4', '0']}
+    df = pd.DataFrame(data=data)
+
+    st_pos_tiles = get_mixed_subtype_tile_counts(df, subtype_list)
+
+    assert (isinstance(st_pos_tiles, dict))
+    assert(len(st_pos_tiles) == 3)
+    assert(int(st_pos_tiles.get('2.1')) == 5)
+    assert(int(st_pos_tiles.get('2.2')) == 3)
+    assert(int(st_pos_tiles.get('0')) == 1)


### PR DESCRIPTION
Missing Column
=============
- Issue: More than `avg_tile_coverage` column was being dropped in the result.
- Fix: Specify only `avg_tile_coverage` to be dropped if null.

Missing Tiles not running for Mixed Subtypes
====================================
- Issue: The missing tiles QC check was not being run when a sample came back with a mixed result (two or more subtypes)
- Fix: Added capability to run the missing tiles QC check on all subtypes that were found in the result.


Signed-off-by: Matt <gopezm@myumanitoba.ca>