### PR TITLE
Fix issue #39 - `zcat < file`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ python:
   - '3.6'
 os:
   - linux
-  - osx
+#  - osx
 
 # Whitelist of branches to run CI Testing on.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ language: python
 python:
   - '3.5'
   - '3.6'
+os:
+  - linux
+  - osx
 
 # Whitelist of branches to run CI Testing on.
 branches:

--- a/bio_hansel/parsers.py
+++ b/bio_hansel/parsers.py
@@ -39,7 +39,7 @@ def parse_fasta(filepath):
         # http://aripollak.com/pythongzipbenchmarks/
         # assumes Linux os with zcat installed
         import os
-        with os.popen('zcat {}'.format(filepath)) as f:
+        with os.popen('zcat < {}'.format(filepath)) as f:
             yield from _parse_fasta(f, filepath)
     else:
         with open(filepath, 'r') as f:
@@ -91,7 +91,7 @@ def parse_fastq(filepath):
         # http://aripollak.com/pythongzipbenchmarks/
         # assumes Linux os with zcat installed
         import os
-        with os.popen('zcat {}'.format(filepath)) as f:
+        with os.popen('zcat < {}'.format(filepath)) as f:
             yield from _parse_fastq(f)
     else:
         with open(filepath, 'rU') as f:


### PR DESCRIPTION
See issue #39 

To test:

```bash
# install bio_hansel
pip install git+https://github.com/phac-nml/bio_hansel.git@fix-39-zcat-mac-osx
# get test data
wget ftp://ftp.sra.ebi.ac.uk/vol1/fastq/SRR120/002/SRR1203042/SRR1203042_1.fastq.gz
# run bio_hansel on test data
hansel SRR1203042_1.fastq.gz
```
should produce output similar to:
```
sample  scheme  scheme_version  subtype all_subtypes    tiles_matching_subtype  are_subtypes_consistent inconsistent_subtypes   n_tiles_matching_all    n_tiles_matching_all_expected      n_tiles_matching_positive       n_tiles_matching_positive_expected      n_tiles_matching_subtype        n_tiles_matching_subtype_expected  file_path       avg_tile_coverage       qc_status       qc_message
SRR1203042      heidelberg      0.5.0   2.2.1.1.2       1; 2.2.1.1.2    2592097-2.2.1.1.2       False   ['1', '2.2.1.1.2']      149     202     3       18['SRR1203042_1.fastq.gz']        14.169934640522875      FAIL    "FAIL: Missing Tiles Error 1: 27.23% missing tiles; more than 5.00% missing tiles threshold. Low coverage depth (14.4 < 20.0 expected); you may need more WGS data. | FAIL: Mixed Sample Error 2: Mixed subtypes found: ""1; 2.2.1.1.2""."
```

specifically the `subtype` equal to `2.2.1.1.2` which indicates that the `fastq.gz` parsing is working correctly under OSX.

This fix works on Mac OSX `10.13.5 Beta` and `10.12.6`