### PR TITLE
Shorten QC messages

### DIFF
--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -17,8 +17,7 @@ def is_overall_coverage_low(st: Subtype, df: DataFrame, p: SubtypingParams) -> T
         return None, None
 
     if st.avg_tile_coverage < p.min_coverage_warning:
-        return QC.WARNING, '{}: Low coverage for all tiles ({:.3f} < {} expected)'.format(
-            QC.LOW_COVERAGE_WARNING,
+        return QC.WARNING, 'Low coverage for all tiles ({:.3f} < {} expected)'.format(
             st.avg_tile_coverage,
             p.min_coverage_warning
         )
@@ -93,20 +92,18 @@ def check_for_missing_tiles(is_fastq: bool, curr_subtype: str, scheme: str,
                     depth,
                     float(p.low_coverage_depth_freq))
             else:
-                coverage_msg = 'Okay coverage depth ({:.1f} >= {:.1f} expected), but this may be the wrong ' \
-                               'serovar or species for scheme "{}"'.format(
-                                depth,
-                                float(p.low_coverage_depth_freq),
-                                scheme)
-            error_messages = '{status}: {p_missing:.2%} missing tiles; more than {p_missing_threshold:.2%} missing ' \
-                             'tiles threshold. {coverage_msg}'.format(
-                                status=QC.MISSING_TILES_ERROR_1,
-                                p_missing=p_missing,
-                                p_missing_threshold=p.max_perc_missing_tiles,
-                                coverage_msg=coverage_msg)
+                coverage_msg = ('Okay coverage depth ({:.1f} >= {:.1f} expected), but this may be the wrong '
+                                'serovar or species for scheme "{}"').format(
+                    depth,
+                    float(p.low_coverage_depth_freq),
+                    scheme)
+            error_messages = ('{p_missing:.2%} missing tiles; more than {p_missing_threshold:.2%} missing '
+                              'tiles threshold. {coverage_msg}').format(
+                p_missing=p_missing,
+                p_missing_threshold=p.max_perc_missing_tiles,
+                coverage_msg=coverage_msg)
         else:
-            error_messages = '{}: {:.2%} missing tiles for subtype {}; more than {:.2%} missing tile threshold'.format(
-                QC.MISSING_TILES_ERROR_1,
+            error_messages = '{:.2%} missing tiles for subtype {}; more than {:.2%} missing tile threshold'.format(
                 p_missing,
                 curr_subtype,
                 p.max_perc_missing_tiles)
@@ -132,18 +129,16 @@ def is_mixed_subtype(st: Subtype, df: DataFrame, *args) -> Tuple[Optional[str], 
     """
     if not st.are_subtypes_consistent:
         return QC.FAIL, \
-               '{}: Mixed subtypes found: "{}".'.format(
-                   QC.MIXED_SAMPLE_ERROR_2,
+               'Mixed subtypes found: "{}".'.format(
                    '; '.join(sorted(st.inconsistent_subtypes)))
     conflicting_tiles = get_conflicting_tiles(st, df)
     if conflicting_tiles is None or conflicting_tiles.shape[0] == 0:
         return None, None
 
-    return QC.FAIL, '{}: Mixed subtype detected. Positive and negative tiles detected for ' \
-                    'the same target site "{}" for subtype "{}".'.format(
-                        QC.MIXED_SAMPLE_ERROR_2,
-                        '; '.join(conflicting_tiles['refposition'].astype(str).tolist()),
-                        st.subtype)
+    return QC.FAIL, ('Mixed subtype detected. Positive and negative tiles detected for '
+                     'the same target site "{}" for subtype "{}".').format(
+        '; '.join(conflicting_tiles['refposition'].astype(str).tolist()),
+        st.subtype)
 
 
 def is_missing_too_many_target_sites(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[
@@ -209,7 +204,7 @@ def is_missing_downstream_targets(st: Subtype, *args) -> Tuple[Optional[str], Op
 
 def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[
     Optional[str], Optional[str]]:
-    '''Is the result a possible intermediate subtype?
+    """Is the result a possible intermediate subtype?
 
     Return a WARNING message if all the conditions are true:
     - 95% of the scheme tiles are found
@@ -224,7 +219,7 @@ def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams
 
     Returns:
         None, None if no intermediate subtype possible; otherwise, "FAIL", error message
-    '''
+    """
     if not st.are_subtypes_consistent \
             or st.subtype is None:
         return None, None
@@ -236,7 +231,7 @@ def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams
     obs = int(st.n_tiles_matching_all)
     exp = int(st.n_tiles_matching_all_expected)
     if (exp - obs) / exp <= p.max_perc_intermediate_tiles and conflicting_tiles.shape[0] == 0 and \
-                    total_subtype_tiles_hits < total_subtype_tiles and num_pos_tiles and num_neg_tiles:
+            total_subtype_tiles_hits < total_subtype_tiles and num_pos_tiles and num_neg_tiles:
         return QC.WARNING, \
                '{}: Possible intermediate subtype. All scheme tiles were found, but a fraction ' \
                'were positive for the final subtype. Total subtype matches observed (n={}) vs expected (n={})'.format(

--- a/bio_hansel/qc/checks.py
+++ b/bio_hansel/qc/checks.py
@@ -17,11 +17,7 @@ def is_overall_coverage_low(st: Subtype, df: DataFrame, p: SubtypingParams) -> T
         return None, None
 
     if st.avg_tile_coverage < p.min_coverage_warning:
-        return QC.WARNING, 'Low coverage for all tiles ({:.3f} < {} expected)'.format(
-            st.avg_tile_coverage,
-            p.min_coverage_warning
-        )
-
+        return QC.WARNING, f'Low coverage for all tiles ({st.avg_tile_coverage:.3f} < {p.min_coverage_warning} expected)'
     return None, None
 
 
@@ -84,30 +80,21 @@ def check_for_missing_tiles(is_fastq: bool, curr_subtype: str, scheme: str,
 
     p_missing = (exp - obs) / exp  # type: float
     if p_missing > p.max_perc_missing_tiles:
+        error_status = QC.FAIL
         if is_fastq:
             tiles_with_hits = df[df['is_kmer_freq_okay']]  # type: DataFrame
             depth = tiles_with_hits['freq'].mean()
             if depth < p.low_coverage_depth_freq:
-                coverage_msg = 'Low coverage depth ({:.1f} < {:.1f} expected); you may need more WGS data.'.format(
-                    depth,
-                    float(p.low_coverage_depth_freq))
+                coverage_msg = f'Low coverage depth ({depth:.1f} < {float(p.low_coverage_depth_freq):.1f} expected); ' \
+                               f'you may need more WGS data.'
             else:
-                coverage_msg = ('Okay coverage depth ({:.1f} >= {:.1f} expected), but this may be the wrong '
-                                'serovar or species for scheme "{}"').format(
-                    depth,
-                    float(p.low_coverage_depth_freq),
-                    scheme)
-            error_messages = ('{p_missing:.2%} missing tiles; more than {p_missing_threshold:.2%} missing '
-                              'tiles threshold. {coverage_msg}').format(
-                p_missing=p_missing,
-                p_missing_threshold=p.max_perc_missing_tiles,
-                coverage_msg=coverage_msg)
+                coverage_msg = f'Okay coverage depth ({depth:.1f} >= {float(p.low_coverage_depth_freq):.1f} expected), ' \
+                               f'but this may be the wrong serovar or species for scheme "{scheme}"'
+            error_messages = f'{p_missing:.2%} missing tiles; more than {p.max_perc_missing_tiles:.2%} missing ' \
+                             f'tiles threshold. {coverage_msg}'
         else:
-            error_messages = '{:.2%} missing tiles for subtype {}; more than {:.2%} missing tile threshold'.format(
-                p_missing,
-                curr_subtype,
-                p.max_perc_missing_tiles)
-        error_status = QC.FAIL
+            error_messages = f'{p_missing:.2%} missing tiles for subtype "{curr_subtype}"; more than ' \
+                             f'{p.max_perc_missing_tiles:.2%} missing tile threshold'
 
     return error_status, error_messages
 
@@ -128,17 +115,15 @@ def is_mixed_subtype(st: Subtype, df: DataFrame, *args) -> Tuple[Optional[str], 
         None, None if not mixed subtype result; otherwise, "FAIL", error message
     """
     if not st.are_subtypes_consistent:
-        return QC.FAIL, \
-               'Mixed subtypes found: "{}".'.format(
-                   '; '.join(sorted(st.inconsistent_subtypes)))
+        return QC.FAIL, f'Mixed subtypes found: "{"; ".join(sorted(st.inconsistent_subtypes))}".'
     conflicting_tiles = get_conflicting_tiles(st, df)
     if conflicting_tiles is None or conflicting_tiles.shape[0] == 0:
         return None, None
 
-    return QC.FAIL, ('Mixed subtype detected. Positive and negative tiles detected for '
-                     'the same target site "{}" for subtype "{}".').format(
-        '; '.join(conflicting_tiles['refposition'].astype(str).tolist()),
-        st.subtype)
+    s = 's' if conflicting_tiles.shape[0] > 1 else ''
+    positions = ', '.join(conflicting_tiles['refposition'].astype(str).tolist())
+    return QC.FAIL, f'Mixed subtype; the positive and negative tiles were found for ' \
+                    f'the same target site{s} {positions} for subtype "{st.subtype}".'
 
 
 def is_missing_too_many_target_sites(st: Subtype, df: DataFrame, p: SubtypingParams) -> Tuple[
@@ -168,11 +153,8 @@ def is_missing_too_many_target_sites(st: Subtype, df: DataFrame, p: SubtypingPar
     exp = int(st.n_tiles_matching_all_expected)
     obs = int(st.n_tiles_matching_all)
     if (exp - obs) / exp <= p.max_perc_missing_tiles and len(missing_targets) >= p.min_ambiguous_tiles:
-        return QC.FAIL, \
-               '{}: {} missing positions detected for subtype: {}.'.format(
-                   QC.AMBIGUOUS_RESULTS_ERROR_3,
-                   len(missing_targets),
-                   st.subtype)
+        return QC.FAIL, f'{QC.AMBIGUOUS_RESULTS_ERROR_3}: There were {len(missing_targets)} missing positions for ' \
+                        f'subtype "{st.subtype}".'
     return None, None
 
 
@@ -192,13 +174,9 @@ def is_missing_downstream_targets(st: Subtype, *args) -> Tuple[Optional[str], Op
         None, None if no missing downstream targets; otherwise, "FAIL", error message
     """
     if st.non_present_subtypes:
-        return QC.FAIL, \
-               '{}: Subtype {} was found, but tiles for downstream subtype(s) "{}" were missing. ' \
-               'Due to missing downstream tiles, there is a lack of confidence in the final subtype call.'.format(
-                   QC.UNCONFIDENT_RESULTS_ERROR_4,
-                   st.subtype,
-                   st.non_present_subtypes)
-
+        return QC.FAIL, f'{QC.UNCONFIDENT_RESULTS_ERROR_4}: Subtype "{st.subtype}" was found, but tiles for ' \
+                        f'downstream subtype(s) "{st.non_present_subtypes}" were missing. Due to missing downstream ' \
+                        f'tiles, there is a lack of confidence in the final subtype call.'
     return None, None
 
 
@@ -232,10 +210,7 @@ def is_maybe_intermediate_subtype(st: Subtype, df: DataFrame, p: SubtypingParams
     exp = int(st.n_tiles_matching_all_expected)
     if (exp - obs) / exp <= p.max_perc_intermediate_tiles and conflicting_tiles.shape[0] == 0 and \
             total_subtype_tiles_hits < total_subtype_tiles and num_pos_tiles and num_neg_tiles:
-        return QC.WARNING, \
-               '{}: Possible intermediate subtype. All scheme tiles were found, but a fraction ' \
-               'were positive for the final subtype. Total subtype matches observed (n={}) vs expected (n={})'.format(
-                   QC.INTERMEDIATE_SUBTYPE_WARNING,
-                   total_subtype_tiles_hits,
-                   total_subtype_tiles)
+        return QC.WARNING, f'Possible intermediate subtype. All scheme tiles were found, but a fraction ' \
+                           f'were positive for the final subtype. Total subtype matches observed ' \
+                           f'(n={total_subtype_tiles_hits}) vs expected (n={total_subtype_tiles})'
     return None, None

--- a/bio_hansel/qc/const.py
+++ b/bio_hansel/qc/const.py
@@ -5,10 +5,7 @@ class QC:
     WARNING = 'WARNING'
     PASS = 'PASS'
     # Errors for Hansel
-    MISSING_TILES_ERROR_1 = 'Missing Tiles Error 1'
-    MIXED_SAMPLE_ERROR_2 = 'Mixed Sample Error 2'
     AMBIGUOUS_RESULTS_ERROR_3 = 'Ambiguous Results Error 3'
     UNCONFIDENT_RESULTS_ERROR_4 = 'Unconfident Results Error 4'
     INTERMEDIATE_SUBTYPE_WARNING = 'Intermediate Subtype'
-    LOW_COVERAGE_WARNING = 'Low Coverage'
     NO_SUBTYPE_RESULT = 'No subtype result!'

--- a/bio_hansel/qc/const.py
+++ b/bio_hansel/qc/const.py
@@ -4,8 +4,6 @@ class QC:
     FAIL = 'FAIL'
     WARNING = 'WARNING'
     PASS = 'PASS'
-    # Errors for Hansel
     AMBIGUOUS_RESULTS_ERROR_3 = 'Ambiguous Results Error 3'
     UNCONFIDENT_RESULTS_ERROR_4 = 'Unconfident Results Error 4'
-    INTERMEDIATE_SUBTYPE_WARNING = 'Intermediate Subtype'
     NO_SUBTYPE_RESULT = 'No subtype result!'

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -90,14 +90,13 @@ def test_mixed_subtype_positive_negative_tiles_same_target():
     assert isinstance(df, DataFrame)
     assert st.scheme == scheme
     assert st.qc_status == QC.FAIL
-    assert 'Mixed subtype detected' in st.qc_message
-    expected_qc_msg = 'FAIL: Mixed subtype detected. ' \
-                      'Positive and negative tiles detected for the same ' \
-                      'target site ' \
-                      '"202001; 600783; 1049933; 1193219; 2778621; 2904061; ' \
-                      '3278067; 3867228; 4499501; 4579224; 4738855; 202001; ' \
-                      '600783; 1049933; 1193219; 2778621; 2904061; 3278067; ' \
-                      '3867228; 4499501; 4579224; 4738855" for subtype "1.1".'
+    expected_qc_msg = ('FAIL: Mixed subtype; the positive and negative tiles were found for the same '
+                      'target sites 202001, 600783, 1049933, 1193219, 2778621, 2904061, '
+                      '3278067, 3867228, 4499501, 4579224, 4738855, 202001, '
+                      '600783, 1049933, 1193219, 2778621, 2904061, 3278067, '
+                      '3867228, 4499501, 4579224, 4738855 for subtype "1.1".')
+    print(st.qc_message)
+    print(expected_qc_msg)
     assert expected_qc_msg in st.qc_message
 
 

--- a/tests/test_qc.py
+++ b/tests/test_qc.py
@@ -20,8 +20,7 @@ def test_low_coverage():
     assert isinstance(df, DataFrame)
     assert st.is_fastq_input()
     assert st.scheme == scheme
-    assert QC.LOW_COVERAGE_WARNING in st.qc_message
-    assert 'Low Coverage: Low coverage for all tiles (7.439 < 20 expected)' in st.qc_message
+    assert 'Low coverage for all tiles (7.439 < 20 expected)' in st.qc_message
     assert st.qc_status == QC.FAIL
 
 
@@ -56,7 +55,6 @@ def test_intermediate_subtype():
     assert isinstance(st, Subtype)
     assert isinstance(df, DataFrame)
     assert st.scheme == scheme
-    assert QC.INTERMEDIATE_SUBTYPE_WARNING in st.qc_message
     assert "Total subtype matches observed (n=3) vs expected (n=6)" in st.qc_message
     assert st.qc_status == QC.WARNING
 
@@ -69,7 +67,6 @@ def test_missing_tiles():
     assert isinstance(df, DataFrame)
     assert st.is_fastq_input()
     assert st.scheme == scheme
-    assert QC.MISSING_TILES_ERROR_1 in st.qc_message
     assert 'Low coverage depth (10.9 < 20.0 expected)' in st.qc_message
     assert st.qc_status == QC.FAIL
 
@@ -81,7 +78,6 @@ def test_mixed_tiles():
     assert isinstance(st, Subtype)
     assert isinstance(df, DataFrame)
     assert st.scheme == scheme
-    assert QC.MIXED_SAMPLE_ERROR_2 in st.qc_message
     assert 'Mixed subtypes found: "1; 2; 2.1"' in st.qc_message
     assert st.qc_status == QC.FAIL
 
@@ -94,8 +90,8 @@ def test_mixed_subtype_positive_negative_tiles_same_target():
     assert isinstance(df, DataFrame)
     assert st.scheme == scheme
     assert st.qc_status == QC.FAIL
-    assert QC.MIXED_SAMPLE_ERROR_2 in st.qc_message
-    expected_qc_msg = 'FAIL: Mixed Sample Error 2: Mixed subtype detected. ' \
+    assert 'Mixed subtype detected' in st.qc_message
+    expected_qc_msg = 'FAIL: Mixed subtype detected. ' \
                       'Positive and negative tiles detected for the same ' \
                       'target site ' \
                       '"202001; 600783; 1049933; 1193219; 2778621; 2904061; ' \


### PR DESCRIPTION
Fixes #46 by removing some redundancy in the QC messages. 

Signed-off-by: pkruczkiewicz <peter.kruczkiewicz@canada.ca>